### PR TITLE
Added new gengo with numeric conversion

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-04-02  Nobuyuki SASAKI  <nathancorvussolis@gmail.com>
+
+	* SKK-JISYO.L: Add one entry.
+	れいわ#ねん /令和#0年/令和#1年/令和#2年/令和#3年/
+
 2019-04-01  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
 
 	* SKK-JISYO.L: Modify entry.


### PR DESCRIPTION
数値変換を含む新元号のエントリを追加。

れいわ#ねん /令和#0年/令和#1年/令和#2年/令和#3年/

ちなみに、数値変換を含む元号の既存のエントリは以下の通り。

めいじ#ねん /明治#0年/明治#1年/明治#2年/明治#3年/
たいしょう#ねん /大正#0年/大正#1年/大正#2年/大正#3年/
しょうわ#ねん /昭和#0年/昭和#1年/昭和#2年/昭和#3年/
へいせい#ねん /平成#0年/平成#1年/平成#2年/平成#3年/
