### PR TITLE
辞書登録・削除希望単語入力フォームにて誤登録で入力されたものへの対応

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,28 @@
+2019-04-06  Nobuyuki SASAKI  <nathancorvussolis@gmail.com>
+
+	* SKK-JISYO.L: Modify below candidates.
+	よもつひらさか /黄泉平坂/{->黄泉比良坂;古事記/泉津平坂;日本書紀/}
+	やつめうなぎ /八目鰻{鱧/->}/
+	ばっさい /伐採/{伐裁/->}
+	せんけん /先遣/先見/専権/先験/浅見/淺見;「浅」旧字/先件/嬋娟;-たる美女/仙建/擅権/選研/選鉱{精->製}錬研究所;※abbrev/
+	よいざm /酔い覚{;->}/酔い醒/酔醒/
+
+	* SKK-JISYO.L: Remove below candidates.
+	かみきょうく /上京区/
+	にしぎょうく /西京区/
+	さいきょうく /西京区/
+	ちゅうきょうく /中京区/
+	しゅんとうぐん /駿東郡/
+
+	* SKK-JISYO.L: Add below candidates.
+	うきょうく /右京区/
+	かみぎょうく /上京区/
+	しもぎょうく /下京区/
+	なかぎょうく /中京区/
+	にしきょうく /西京区/
+	ひがしやまく /東山区/
+	すんとうぐん /駿東郡/
+
 2019-04-02  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
 
 	* SKK-JISYO.L: Modify entry.


### PR DESCRIPTION
辞書登録・削除希望単語入力フォームにて誤登録で入力されたものへの対応
http://openlab.jp/skk/registdic.cgi

不正確なのはちょっとどうかと思ったので、とりあえず誤登録のみ対応してみました。

---

04/04/19 22:06:39	にしぎょうく /西京区/	誤登録	読み間違いのため。
04/04/19 22:05:49	さいきょうく /西京区/	誤登録	読み間違いのため。
04/04/19 22:04:40	にしきょうく /西京区/	地名

「西京区」の読みは「にしきょうく」が正しい。
https://www.city.kyoto.lg.jp/nisikyo/
https://ja.wikipedia.org/wiki/%E8%A5%BF%E4%BA%AC%E5%8C%BA

以下を追加。
にしきょうく /西京区/

以下を削除。
さいきょうく /西京区/
にしぎょうく /西京区/

ついでに京都市の行政区を整理した。

以下を追加。
うきょうく /右京区/
かみぎょうく /上京区/
しもぎょうく /下京区/
なかぎょうく /中京区/
ひがしやまく /東山区/

以下を削除。
かみきょうく /上京区/
ちゅうきょうく /中京区/

---

12/31/17 09:27:59 よもつひらさか /黄泉平坂/ 誤登録 正しくは黄泉比良坂です

よもつひらさか /黄泉平坂/{->黄泉比良坂;古事記/泉津平坂;日本書紀/}

「黄泉平坂」は辞書に記載があり間違いとは言えないので残す。
https://dictionary.goo.ne.jp/jn/228446/meaning/m0u/

古事記の原文では「黄泉比良坂」の表記なので追加。
http://www.seisaku.bz/kojiki/kojiki_02.html

日本書紀の原文では「泉津平坂」の表記なので追加。
http://www.seisaku.bz/nihonshoki/shoki_01.html

---

07/21/17 20:26:42	やつめうなぎ /鱧/	誤登録	やつめうなぎがはもになっています

やつめうなぎ /八目鰻{鱧/->}/

---

01/30/15 16:40:42	ばっさい /伐裁/	誤登録	正しい「伐採」が登録されています。

ばっさい /伐採/{伐裁/->}

---

01/23/14 19:06:19	せんけん /選鉱精錬研究所/	誤登録	東北大学にあった組織であれば、選鉱製錬研究所です。

せんけん /先遣/先見/専権/先験/浅見/淺見;「浅」旧字/先件/嬋娟;-たる美女/仙建/擅権/選研/選鉱{精->製}錬研究所;※abbrev/

---

11/21/12 18:44:07	しゅんとうぐん /駿東郡/	誤登録	すんとうぐん

以下を削除。
しゅんとうぐん /駿東郡/

以下を追加。
すんとうぐん /駿東郡/

---

その他

注釈の記号を削除
よいざm /酔い覚{;->}/酔い醒/酔醒/
