### PR TITLE
Use TOOLS_DIR for SKK-JISYO.edict2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-01-26  Tatsuya Kinoshita  <tats@debian.org>
+
+	* Makefile (SKK-JISYO.edict2): Use TOOLS_DIR.
+
 2020-12-26  Tetsuo Tsukamoto  <tt.tetsuo.tsukamoto@gmail.com>
 
 	* SKK-JISYO.pinyin: New file.

--- a/Makefile
+++ b/Makefile
@@ -207,8 +207,8 @@ cldr-common.zip:
 
 SKK-JISYO.edict2: edict2u
 	$(MV) SKK-JISYO.edict2 SKK-JISYO.edict2.ORIG
-	$(EMACS) --load ../tools/convert2skk/edict2toskk.el --funcall main | $(EXPR2) > SKK-JISYO.edict2.tmp
-	$(EMACS) --load ../tools/convert2skk/edict2toskk.el --funcall after
+	$(EMACS) --load $(TOOLS_DIR)/convert2skk/edict2toskk.el --funcall main | $(EXPR2) > SKK-JISYO.edict2.tmp
+	$(EMACS) --load $(TOOLS_DIR)/convert2skk/edict2toskk.el --funcall after
 	$(MV) SKK-JISYO.edict2.tmp SKK-JISYO.edict2
 	$(GZIP) -fc SKK-JISYO.edict2 > SKK-JISYO.edict2.gz
 	$(MD5) SKK-JISYO.edict2.gz > SKK-JISYO.edict2.gz.md5


### PR DESCRIPTION
* Makefile (SKK-JISYO.edict2): Use TOOLS_DIR.

TOOLS_DIR is defined to use a different place than "../tools".
