### PR TITLE
SKK-JISYO.fullname のライセンスを明確にする

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-06-17  HARUYAMA Seigo <haruyama@unixuser.org>
+
+	* committers.md: Specify the license of SKK-JISYO.fullname.
+
 2024-01-31  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
 
 	* README.md: Update.

--- a/committers.md
+++ b/committers.md
@@ -10,6 +10,7 @@ SKK 辞書 committer のみなさまへ
 - SKK-JISYO.law
 - SKK-JISYO.wrong
 - SKK-JISYO.jinmei
+- SKK-JISYO.fullname
 - SKK-JISYO.lisp
 
 上記の各辞書については、 the Free Software Foundation が発行している


### PR DESCRIPTION
#29 を引き継いで [辞書登録・削除希望単語入力フォーム](http://openlab.ring.gr.jp/skk/registdic.cgi) から追加などをしていけたらと思い見ていたところ SKK-JISYO.fullname のライセンスが明確になっていないようです
SKK-JISYO.jinmei と同じ扱いかと思いますので SKK-JISYO.jinmei の後に追加しました